### PR TITLE
feat: allow all accounts in the organization to be displayed

### DIFF
--- a/deploy/aws-sam/template.yaml
+++ b/deploy/aws-sam/template.yaml
@@ -18,8 +18,9 @@ Parameters:
     MinLength: 0
   OuId:
     Type: String
-    Description: 'A Root ID or an OrganizationalUnit (OU) ID of your AWS Organization. aws-bills-on-slack fetchs the cost of AWS accounts under the specified Root or OU.'
-    AllowedPattern: '^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$'
+    Description: 'A Root ID or an OrganizationalUnit (OU) ID of your AWS Organization. aws-bills-on-slack fetches the cost of AWS accounts under the specified Root or OU. If left blank, costs are fetched for all accounts in your organization.'
+    AllowedPattern: '^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})|()$'
+    Default: ""
   SlackIncomingWebhookUrl:
     Type: String
     Description: 'A url of Slack Incoming Webhook. See the doc to get your own - '
@@ -32,6 +33,12 @@ Parameters:
 Globals:
   Function:
     Timeout: 10
+
+Conditions:
+  IsOuIdEmpty:
+    !Equals
+      - !Ref OuId
+      - ""
 
 Resources:
   AwsBillsOnSlackFunc:
@@ -53,7 +60,10 @@ Resources:
           - Sid: AllowListAccountsAndGetCosts
             Effect: Allow
             Action:
-            - organizations:ListAccountsForParent
+            - !If
+              - IsOuIdEmpty
+              - organizations:ListAccounts
+              - organizations:ListAccountsForParent
             - ce:GetCostAndUsage
             Resource: '*'
       Events:

--- a/main.go
+++ b/main.go
@@ -26,10 +26,6 @@ func handler(ctx context.Context, event interface{}) ([]byte, error) {
 	var accounts acos.Accounts
 
 	ouId := os.Getenv("OU_ID")
-	if ouId == "" {
-		// Try to get ROOT_OU_ID if OU_ID is not specified
-		ouId = os.Getenv("ROOT_OU_ID")
-	}
 	if ouId != "" {
 		// Get all AWS accounts in the specified OU
 		if accounts, err = acos.ListAccountsByOu(ctx, ouId); err != nil {


### PR DESCRIPTION
I have made changes so that you can get the costs for all accounts in your organization.

- allowed `OuId` to be set to an empty string.
- added `organizations:ListAccounts` to the policy (using `Conditions` to minimize permissions)